### PR TITLE
Several fixes to bring in line with spec

### DIFF
--- a/src/csp.types.ts
+++ b/src/csp.types.ts
@@ -8,7 +8,7 @@ type SchemeSource = typeof schemeSource[number];
 
 // Hosts Source Definition
 type HostProtocolSchemes = `${string}://` | ''
-type PortScheme = `:${number}` | ''
+type PortScheme = `:${number}` | '' | ':*'
 /** Can actually be any string, but typed with `string.string` to restrict the combined optional types from all just bing `string` */
 type HostNameScheme = `${string}.${string}`
 type HostSource = `${HostProtocolSchemes}${HostNameScheme}${PortScheme}`

--- a/src/csp.types.ts
+++ b/src/csp.types.ts
@@ -10,7 +10,7 @@ type SchemeSource = typeof schemeSource[number];
 type HostProtocolSchemes = `${string}://` | ''
 type PortScheme = `:${number}` | '' | ':*'
 /** Can actually be any string, but typed with `string.string` to restrict the combined optional types from all just bing `string` */
-type HostNameScheme = `${string}.${string}`
+type HostNameScheme = `${string}.${string}` | `${string}`
 type HostSource = `${HostProtocolSchemes}${HostNameScheme}${PortScheme}`
 
 // Crypto Source Definition

--- a/src/csp.types.ts
+++ b/src/csp.types.ts
@@ -29,13 +29,9 @@ type UriPath = `${HttpDelineators}${string}`
 export const baseSources = ['self', 'unsafe-eval', 'unsafe-hashes', 'unsafe-inline', 'none'] as const;
 type BaseSources = typeof baseSources[number]
 
-// strict-dynamic
-export const strictDynamic = ['strict-dynamic'] as const;
-type StrictDynamic = typeof strictDynamic[number]
-
 // Combined all source directives
 export const source = [...baseSources, ...schemeSource] as const;
-export type Source = BaseSources | HostSource | SchemeSource | CryptoSources | StrictDynamic
+export type Source = BaseSources | HostSource | SchemeSource | CryptoSources
 type Sources = Source | Source[]
 
 export const referrerHeaderOptions = [
@@ -82,7 +78,7 @@ type ChildDirectives = {
 
 type SourceDirectives = {
 	'connect-src'?: Sources
-	'default-src'?: Sources
+	'default-src'?: ActionSource | ActionSource[]
 	'font-src'?: Sources
 	'frame-src'?: Sources
 	'img-src'?: Sources
@@ -90,7 +86,7 @@ type SourceDirectives = {
 	'media-src'?: Sources
 	'object-src'?: Sources
 	'prefetch-src'?: Sources
-	'script-src'?: Sources
+	'script-src'?: ActionSource | ActionSource[]
 	'script-src-elem'?: Sources
 	'script-src-attr'?: Sources
 	'style-src'?: Sources
@@ -264,7 +260,6 @@ export const directiveValuesByCategory = {
 		},
 	],
 	baseSources,
-	strictDynamic,
 	primitiveSourceBool: [
 		true,
 		false,
@@ -315,7 +310,7 @@ export const directiveValuesByCategory = {
 
 export const directiveMap: Readonly<Record<(keyof Directives),Readonly<(keyof typeof directiveValuesByCategory)[]>>> = {
 	'child-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
-	'default-src': ['hostSource', 'schemeSource', 'cryptoSource', 'baseSources', 'strictDynamic'],
+	'default-src': ['hostSource', 'schemeSource', 'cryptoSource', 'baseSources', 'actionSource'],
 	'frame-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'worker-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'connect-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
@@ -325,7 +320,7 @@ export const directiveMap: Readonly<Record<(keyof Directives),Readonly<(keyof ty
 	'media-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'object-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'prefetch-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
-	'script-src': ['hostSource','schemeSource','cryptoSource','baseSources', 'strictDynamic'],
+	'script-src': ['hostSource','schemeSource','cryptoSource','baseSources', 'actionSource'],
 	'script-src-elem': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'script-src-attr': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'style-src': ['hostSource','schemeSource','cryptoSource','baseSources'],

--- a/src/csp.types.ts
+++ b/src/csp.types.ts
@@ -7,8 +7,7 @@ export const schemeSource = ['http:', 'https:', 'data:', 'mediastream:', 'blob:'
 type SchemeSource = typeof schemeSource[number];
 
 // Hosts Source Definition
-export const hostProtocolScheme = ['http://', 'https://', ''] as const;
-type HostProtocolSchemes = typeof hostProtocolScheme[number];
+type HostProtocolSchemes = `${string}://` | ''
 type PortScheme = `:${number}` | ''
 /** Can actually be any string, but typed with `string.string` to restrict the combined optional types from all just bing `string` */
 type HostNameScheme = `${string}.${string}`
@@ -232,7 +231,7 @@ export const directiveValuesByCategory = {
 			consumes: {
 				'Port': 'number',
 				'Hostname': 'string',
-				'Protocol': hostProtocolScheme,
+				'Protocol': 'string://',
 			},
 			compose: (args: {
 				'Port'?: number,

--- a/src/csp.types.ts
+++ b/src/csp.types.ts
@@ -29,9 +29,13 @@ type UriPath = `${HttpDelineators}${string}`
 export const baseSources = ['self', 'unsafe-eval', 'unsafe-hashes', 'unsafe-inline', 'none'] as const;
 type BaseSources = typeof baseSources[number]
 
+// strict-dynamic
+export const strictDynamic = ['strict-dynamic'] as const;
+type StrictDynamic = typeof strictDynamic[number]
+
 // Combined all source directives
 export const source = [...baseSources, ...schemeSource] as const;
-export type Source = BaseSources | HostSource | SchemeSource | CryptoSources
+export type Source = BaseSources | HostSource | SchemeSource | CryptoSources | StrictDynamic
 type Sources = Source | Source[]
 
 export const referrerHeaderOptions = [
@@ -78,6 +82,7 @@ type ChildDirectives = {
 
 type SourceDirectives = {
 	'connect-src'?: Sources
+	'default-src'?: Sources
 	'font-src'?: Sources
 	'frame-src'?: Sources
 	'img-src'?: Sources
@@ -259,6 +264,7 @@ export const directiveValuesByCategory = {
 		},
 	],
 	baseSources,
+	strictDynamic,
 	primitiveSourceBool: [
 		true,
 		false,
@@ -309,6 +315,7 @@ export const directiveValuesByCategory = {
 
 export const directiveMap: Readonly<Record<(keyof Directives),Readonly<(keyof typeof directiveValuesByCategory)[]>>> = {
 	'child-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
+	'default-src': ['hostSource', 'schemeSource', 'cryptoSource', 'baseSources', 'strictDynamic'],
 	'frame-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'worker-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'connect-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
@@ -318,7 +325,7 @@ export const directiveMap: Readonly<Record<(keyof Directives),Readonly<(keyof ty
 	'media-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'object-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'prefetch-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
-	'script-src': ['hostSource','schemeSource','cryptoSource','baseSources'],
+	'script-src': ['hostSource','schemeSource','cryptoSource','baseSources', 'strictDynamic'],
 	'script-src-elem': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'script-src-attr': ['hostSource','schemeSource','cryptoSource','baseSources'],
 	'style-src': ['hostSource','schemeSource','cryptoSource','baseSources'],

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -58,6 +58,7 @@ describe('new CspDirectives()',() => {
 			const sampleSha256 = `sha256-${sample64Hash('sha256')}` as const;
 			const csp: Directives = {
 				'child-src': 'none',
+				'default-src': 'self',
 				'frame-src': 'unsafe-eval',
 				'connect-src': 'example.com',
 				'font-src': 'https:',
@@ -66,7 +67,7 @@ describe('new CspDirectives()',() => {
 				'media-src': sampleSha256,
 				'object-src': 'example.com:443',
 				'prefetch-src': sampleSha256,
-				'script-src': sampleSha256,
+				'script-src': 'strict-dynamic',
 				'script-src-elem': sampleSha256,
 				'script-src-attr': sampleSha256,
 				'style-src': sampleSha256,


### PR DESCRIPTION
Things missing which are int he spec, added in this PR:

* `default-src`
* `strict-dynamic` for `script-src` and `default-src` (where it only applies to scripts)
* Host sources can be arbitrary strings, not just `http` and `https` (like `ws` for websocket)
* Port numbers can use wildcard to accept all ports

I haven't set up `strict-dynamic` to only be valid on `default-src` and `script-src`, but that kind of checking seems to not exist at least on the typescript side for anything?