### PR TITLE
fix wildcards being quoted

### DIFF
--- a/src/csp.types.ts
+++ b/src/csp.types.ts
@@ -29,7 +29,7 @@ type HttpDelineators = typeof httpDelineators[number];
 type UriPath = `${HttpDelineators}${string}`
 
 // Base Source Directives
-export const baseSources = ['self', 'unsafe-eval', 'unsafe-hashes', 'unsafe-inline', 'none'] as const;
+export const baseSources = ['self', 'unsafe-eval', 'unsafe-hashes', 'unsafe-inline', 'none', '*'] as const;
 type BaseSources = typeof baseSources[number]
 
 // Combined all source directives

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ const PolicySet = new Set([
 	...sandboxDirectives,
 ]);
 function isQuotedPolicy (policy: string): boolean {
+	if (policy === '*') return false;
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
 	if (PolicySet.has(policy)) return true;

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -107,5 +107,18 @@ describe('new CspDirectives()',() => {
 			}
 			expect(inst.getHeaders).toThrowError();
 		});
+
+		it('supports wildcards',() => {
+			const csp: Directives = {
+				'style-src': ['*', 'data:'],
+			};
+			const inst = new CspDirectives(csp, [], csp);
+			expect(inst.getHeaders()).toStrictEqual({
+				'Content-Security-Policy-Report-Only': 'style-src * data:;',
+				'Content-Security-Policy': "style-src * data:;",
+				'Report-To': '',
+				'Referrer-Policy': 'strict-origin-when-cross-origin',
+			});
+		});
 	});
 });


### PR DESCRIPTION
[as per the spec](https://www.w3.org/TR/CSP3/#grammardef-host-part), `*` shoud not be surrounded by quotes