### PR TITLE
Add wasm-unsafe-eval to script-src directive

### DIFF
--- a/src/csp.types.ts
+++ b/src/csp.types.ts
@@ -29,7 +29,7 @@ type HttpDelineators = typeof httpDelineators[number];
 type UriPath = `${HttpDelineators}${string}`
 
 // Base Source Directives
-export const baseSources = ['self', 'unsafe-eval', 'unsafe-hashes', 'unsafe-inline', 'none', '*'] as const;
+export const baseSources = ['self', 'unsafe-eval', 'wasm-unsafe-eval', 'unsafe-hashes', 'unsafe-inline', 'none', '*'] as const;
 type BaseSources = typeof baseSources[number]
 
 // Combined all source directives


### PR DESCRIPTION
[wasm-unsafe-eval](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution) is useful For cases in which WebAssembly execution is required, 
but `unsafe-eval` is too permissive.

